### PR TITLE
Tag based migrations.

### DIFF
--- a/drupal/rootfs/etc/s6-overlay/scripts/install.sh
+++ b/drupal/rootfs/etc/s6-overlay/scripts/install.sh
@@ -51,7 +51,7 @@ function configure {
 	drush --root=/var/www/drupal --uri="${DRUPAL_DRUSH_URI}" cache:rebuild
 	drush --root=/var/www/drupal --uri="${DRUPAL_DRUSH_URI}" user:role:add fedoraadmin admin
 	drush --root=/var/www/drupal --uri="${DRUPAL_DRUSH_URI}" pm:uninstall pgsql sqlite
-	drush --root=/var/www/drupal --uri="${DRUPAL_DRUSH_URI}" migrate:import --userid=1 islandora_tags,islandora_defaults_tags,islandora_fits_tags
+	drush --root=/var/www/drupal --uri="${DRUPAL_DRUSH_URI}" migrate:import --userid=1 --tag=islandora
 	# Pause queue consumption during import.
 	pause_queues
 	# Ingest Content via Workbench.


### PR DESCRIPTION
This PR allows the sandbox to get the mirador module's mirador tag.

On par with https://github.com/Islandora-Devops/isle-site-template/pull/38