### PR TITLE
Add turnstile protection to the sandbox

### DIFF
--- a/.env
+++ b/.env
@@ -51,3 +51,5 @@ DEVELOPMENT_ENVIRONMENT=false
 URI_SCHEME="https"
 
 TLS_PROVIDER="letsencrypt"
+ACME_EMAIL=community@islandora.ca
+ACME_URL=https://acme-v02.api.letsencrypt.org/directory

--- a/README.md
+++ b/README.md
@@ -121,7 +121,8 @@ for non-destroy actions, and then runs the requested Terraform action.
 Terraform reads the base environment from [.env](./.env) and writes
 workspace-specific `DOMAIN` and `TAG` values into the VM Ignition payload.
 During VM bootstrap, [rootfs/opt/sandbox/setup.sh](./rootfs/opt/sandbox/setup.sh)
-clones [isle-site-template], copies the generated `.env` and secrets, then runs
+installs the required host tools, clones [isle-site-template], enables the
+`bot-mitigation` component, copies the generated `.env` and secrets, then runs
 `make init build demo-objects`.
 
 The default droplet size is `s-4vcpu-8gb-amd`, matching the imported sandbox

--- a/rootfs/opt/sandbox/docker-compose.override.yml
+++ b/rootfs/opt/sandbox/docker-compose.override.yml
@@ -1,28 +1,5 @@
 services:
   traefik:
-    command: >-
-      --ping=true
-      --log.level=INFO
-      --entryPoints.http.address=:80
-      --entryPoints.http.forwardedHeaders.trustedIPs=${FRONTEND_IP_1},${FRONTEND_IP_2},${FRONTEND_IP_3}
-      --entryPoints.http.transport.respondingTimeouts.readTimeout=60
-      --entryPoints.https.address=:443
-      --entryPoints.https.forwardedHeaders.trustedIPs=${FRONTEND_IP_1},${FRONTEND_IP_2},${FRONTEND_IP_3}
-      --entryPoints.https.transport.respondingTimeouts.readTimeout=60
-      --providers.file.directory=/etc/traefik/dynamic
-      --providers.docker=true
-      --providers.docker.network=default
-      --providers.docker.exposedByDefault=false
-      --api.insecure=false
-      --api.dashboard=false
-      --api.debug=false
-      --entrypoints.https.http.tls.certResolver=letsencrypt
-      --certificatesresolvers.letsencrypt.acme.httpchallenge=true
-      --certificatesresolvers.letsencrypt.acme.httpchallenge.entrypoint=http
-      --certificatesresolvers.letsencrypt.acme.storage=/acme/acme.json
-      --certificatesresolvers.letsencrypt.acme.email=community@islandora.ca
-      --certificatesresolvers.letsencrypt.acme.caserver=https://acme-v02.api.letsencrypt.org/directory
-      --experimental.localPlugins.captcha-protect.modulename=github.com/libops/captcha-protect
     volumes:
       # the sandbox gets rebuilt every night
       # so persist ACME certs outside the docker volumes that get only have a 1d lifecycle

--- a/rootfs/opt/sandbox/docker-compose.override.yml
+++ b/rootfs/opt/sandbox/docker-compose.override.yml
@@ -22,6 +22,7 @@ services:
       --certificatesresolvers.letsencrypt.acme.storage=/acme/acme.json
       --certificatesresolvers.letsencrypt.acme.email=community@islandora.ca
       --certificatesresolvers.letsencrypt.acme.caserver=https://acme-v02.api.letsencrypt.org/directory
+      --experimental.localPlugins.captcha-protect.modulename=github.com/libops/captcha-protect
     volumes:
       # the sandbox gets rebuilt every night
       # so persist ACME certs outside the docker volumes that get only have a 1d lifecycle

--- a/rootfs/opt/sandbox/setup.sh
+++ b/rootfs/opt/sandbox/setup.sh
@@ -70,6 +70,7 @@ sitectl config set-context sandbox \
   --project-name sandbox
 
 sitectl component set bot-mitigation on --yolo
+sitectl component set isle-tls enabled --tls-mode letsencrypt --yolo
 
 cp /opt/sandbox/.env .
 cp /opt/sandbox/docker-compose.override.yml .

--- a/rootfs/opt/sandbox/setup.sh
+++ b/rootfs/opt/sandbox/setup.sh
@@ -10,6 +10,17 @@ DOCKER_BUILDX_VERSION=v0.34.1
 # shellcheck disable=SC1091
 source /opt/sandbox/profile.sh
 
+install -d /etc/yum.repos.d
+cat >/etc/yum.repos.d/sitectl.repo <<'EOF'
+[sitectl]
+name=sitectl
+baseurl=https://packages.libops.io/sitectl/rpm
+enabled=1
+gpgcheck=0
+repo_gpgcheck=1
+gpgkey=https://packages.libops.io/sitectl/sitectl-archive-keyring.asc
+EOF
+
 # Install docker-compose (replaces install-docker-compose.service)
 if [ ! -f "/usr/local/lib/docker/cli-plugins/docker-compose" ]; then
   mkdir -p /usr/local/lib/docker/cli-plugins
@@ -27,9 +38,16 @@ if [ ! -f "/usr/local/lib/docker/cli-plugins/docker-buildx" ]; then
   chmod a+x /usr/local/lib/docker/cli-plugins/docker-buildx
 fi
 
-# Install make (replaces install-make.service)
+# Install host packages (replaces install-make.service)
+packages=()
 if [ ! -f /usr/bin/make ]; then
-  rpm-ostree install --apply-live make
+  packages+=(make)
+fi
+if ! rpm -q sitectl-isle >/dev/null 2>&1; then
+  packages+=(sitectl-isle)
+fi
+if [ "${#packages[@]}" -gt 0 ]; then
+  rpm-ostree install --apply-live "${packages[@]}"
 fi
 
 # Clone and initialise isle-site-template (replaces setup-sandbox.service)
@@ -44,6 +62,8 @@ if [ ! -d /opt/sandbox/isle-site-template ]; then
 fi
 
 pushd /opt/sandbox/isle-site-template
+
+sitectl component set bot-mitigation on --yolo
 
 cp /opt/sandbox/.env .
 cp /opt/sandbox/docker-compose.override.yml .

--- a/rootfs/opt/sandbox/setup.sh
+++ b/rootfs/opt/sandbox/setup.sh
@@ -62,6 +62,12 @@ if [ ! -d /opt/sandbox/isle-site-template ]; then
 fi
 
 pushd /opt/sandbox/isle-site-template
+export HOME=/var/home/core
+sitectl config set-context sandbox \
+  --type local \
+  --plugin isle \
+  --project-dir $(pwd) \
+  --project-name sandbox
 
 sitectl component set bot-mitigation on --yolo
 


### PR DESCRIPTION
it'll just be using cloudflare's test keys which is akin to a JS challenge. We can add real keys if bots are running JS but most don't as of today.